### PR TITLE
Adds Extension to Dataset; Adds Index to, Removes Class and Version from Dimension

### DIFF
--- a/src/main/java/no/ssb/jsonstat/v2/Dataset.java
+++ b/src/main/java/no/ssb/jsonstat/v2/Dataset.java
@@ -38,7 +38,7 @@ public class Dataset extends JsonStat {
     private Instant updated = null;
     private Map<String, Dimension> dimension;
     private List<Number> value;
-    private ImmutableMap<String, String> extension;
+    private Object extension;
 
     protected Dataset(ImmutableSet<String> id, ImmutableList<Integer> size) {
         super(Version.TWO, Class.DATASET);
@@ -86,7 +86,7 @@ public class Dataset extends JsonStat {
         return size;
     }
 
-    public Optional<ImmutableMap<String, String>> getExtension() {
+    public Optional<Object> getExtension() {
       return Optional.ofNullable(extension);
     }
 
@@ -285,7 +285,7 @@ public class Dataset extends JsonStat {
 
         private final ImmutableSet.Builder<Dimension.Builder> dimensionBuilders;
         private final ImmutableList.Builder<Optional<Number>> values;
-        private final ImmutableMap.Builder<String, String> extension;
+        private Object extension;
         private String label;
         private String source;
         private Instant update;
@@ -293,7 +293,7 @@ public class Dataset extends JsonStat {
         private Builder() {
             this.dimensionBuilders = ImmutableSet.builder();
             this.values = ImmutableList.builder();
-            this.extension = ImmutableMap.builder();
+            this.extension = null;
         }
 
         public Builder withLabel(final String label) {
@@ -311,8 +311,8 @@ public class Dataset extends JsonStat {
             return this;
         }
 
-        public Builder withExtension(ImmutableMap<String, String> extension) {
-            this.extension.putAll(extension);
+        public Builder withExtensionReference(Object extension) {
+            this.extension = extension;
             return this;
         }
 
@@ -350,7 +350,7 @@ public class Dataset extends JsonStat {
             dataset.updated = update;
             dataset.value = values.build().stream().map(number -> number.isPresent() ? number.get() : null).collect(Collectors.toList());
             dataset.dimension = dimensionMap;
-            dataset.extension = this.extension.build();
+            dataset.extension = this.extension;
 
             return dataset;
         }

--- a/src/main/java/no/ssb/jsonstat/v2/Dataset.java
+++ b/src/main/java/no/ssb/jsonstat/v2/Dataset.java
@@ -38,7 +38,7 @@ public class Dataset extends JsonStat {
     private Instant updated = null;
     private Map<String, Dimension> dimension;
     private List<Number> value;
-    private Object extension;
+    private ImmutableMap<String, String> extension;
 
     protected Dataset(ImmutableSet<String> id, ImmutableList<Integer> size) {
         super(Version.TWO, Class.DATASET);
@@ -86,7 +86,7 @@ public class Dataset extends JsonStat {
         return size;
     }
 
-    public Optional<Object> getExtension() {
+    public Optional<ImmutableMap<String, String>> getExtension() {
       return Optional.ofNullable(extension);
     }
 
@@ -285,7 +285,7 @@ public class Dataset extends JsonStat {
 
         private final ImmutableSet.Builder<Dimension.Builder> dimensionBuilders;
         private final ImmutableList.Builder<Optional<Number>> values;
-        private Object extension;
+        private final ImmutableMap.Builder<String, String> extension;
         private String label;
         private String source;
         private Instant update;
@@ -293,7 +293,7 @@ public class Dataset extends JsonStat {
         private Builder() {
             this.dimensionBuilders = ImmutableSet.builder();
             this.values = ImmutableList.builder();
-            this.extension = null;
+            this.extension = ImmutableMap.builder();
         }
 
         public Builder withLabel(final String label) {
@@ -311,8 +311,8 @@ public class Dataset extends JsonStat {
             return this;
         }
 
-        public Builder withExtensionReference(Object extension) {
-            this.extension = extension;
+        public Builder withExtension(ImmutableMap<String, String> extension) {
+            this.extension.putAll(extension);
             return this;
         }
 
@@ -350,7 +350,7 @@ public class Dataset extends JsonStat {
             dataset.updated = update;
             dataset.value = values.build().stream().map(number -> number.isPresent() ? number.get() : null).collect(Collectors.toList());
             dataset.dimension = dimensionMap;
-            dataset.extension = this.extension;
+            dataset.extension = this.extension.build();
 
             return dataset;
         }

--- a/src/main/java/no/ssb/jsonstat/v2/Dataset.java
+++ b/src/main/java/no/ssb/jsonstat/v2/Dataset.java
@@ -38,6 +38,7 @@ public class Dataset extends JsonStat {
     private Instant updated = null;
     private Map<String, Dimension> dimension;
     private List<Number> value;
+    private ImmutableMap<String, String> extension;
 
     protected Dataset(ImmutableSet<String> id, ImmutableList<Integer> size) {
         super(Version.TWO, Class.DATASET);
@@ -83,6 +84,10 @@ public class Dataset extends JsonStat {
         // Cannot be empty. Should retain order.
         // Should be same order and size than id.
         return size;
+    }
+
+    public Optional<ImmutableMap<String, String>> getExtension() {
+      return Optional.ofNullable(extension);
     }
 
     /**
@@ -280,6 +285,7 @@ public class Dataset extends JsonStat {
 
         private final ImmutableSet.Builder<Dimension.Builder> dimensionBuilders;
         private final ImmutableList.Builder<Optional<Number>> values;
+        private final ImmutableMap.Builder<String, String> extension;
         private String label;
         private String source;
         private Instant update;
@@ -287,6 +293,7 @@ public class Dataset extends JsonStat {
         private Builder() {
             this.dimensionBuilders = ImmutableSet.builder();
             this.values = ImmutableList.builder();
+            this.extension = ImmutableMap.builder();
         }
 
         public Builder withLabel(final String label) {
@@ -301,6 +308,11 @@ public class Dataset extends JsonStat {
 
         public Builder updatedAt(final Instant update) {
             this.update = checkNotNull(update, "updated was null");
+            return this;
+        }
+
+        public Builder withExtension(ImmutableMap<String, String> extension) {
+            this.extension.putAll(extension);
             return this;
         }
 
@@ -338,6 +350,7 @@ public class Dataset extends JsonStat {
             dataset.updated = update;
             dataset.value = values.build().stream().map(number -> number.isPresent() ? number.get() : null).collect(Collectors.toList());
             dataset.dimension = dimensionMap;
+            dataset.extension = this.extension.build();
 
             return dataset;
         }

--- a/src/main/java/no/ssb/jsonstat/v2/Dataset.java
+++ b/src/main/java/no/ssb/jsonstat/v2/Dataset.java
@@ -38,7 +38,7 @@ public class Dataset extends JsonStat {
     private Instant updated = null;
     private Map<String, Dimension> dimension;
     private List<Number> value;
-    private ImmutableMap extension;
+    private ImmutableMap extension = null;
 
     protected Dataset(ImmutableSet<String> id, ImmutableList<Integer> size) {
         super(Version.TWO, Class.DATASET);
@@ -349,7 +349,10 @@ public class Dataset extends JsonStat {
             dataset.updated = update;
             dataset.value = values.build().stream().map(number -> number.isPresent() ? number.get() : null).collect(Collectors.toList());
             dataset.dimension = dimensionMap;
-            dataset.extension = this.extension.build();
+
+            // ImmutableMap.Builder has no way to check the size of the map to be built.
+            ImmutableMap builtExtension = this.extension.build();
+            dataset.extension = (builtExtension.size() > 0) ? builtExtension : null;
 
             return dataset;
         }

--- a/src/main/java/no/ssb/jsonstat/v2/Dataset.java
+++ b/src/main/java/no/ssb/jsonstat/v2/Dataset.java
@@ -38,7 +38,7 @@ public class Dataset extends JsonStat {
     private Instant updated = null;
     private Map<String, Dimension> dimension;
     private List<Number> value;
-    private ImmutableMap<String, String> extension;
+    private ImmutableMap extension;
 
     protected Dataset(ImmutableSet<String> id, ImmutableList<Integer> size) {
         super(Version.TWO, Class.DATASET);
@@ -86,7 +86,7 @@ public class Dataset extends JsonStat {
         return size;
     }
 
-    public Optional<ImmutableMap<String, String>> getExtension() {
+    public Optional<ImmutableMap> getExtension() {
       return Optional.ofNullable(extension);
     }
 
@@ -285,7 +285,7 @@ public class Dataset extends JsonStat {
 
         private final ImmutableSet.Builder<Dimension.Builder> dimensionBuilders;
         private final ImmutableList.Builder<Optional<Number>> values;
-        private final ImmutableMap.Builder<String, String> extension;
+        private final ImmutableMap.Builder extension;
         private String label;
         private String source;
         private Instant update;
@@ -311,14 +311,13 @@ public class Dataset extends JsonStat {
             return this;
         }
 
-        public Builder withExtension(ImmutableMap<String, String> extension) {
+        public Builder withExtension(ImmutableMap extension) {
             this.extension.putAll(extension);
             return this;
         }
 
         public Builder withDimension(Dimension.Builder dimension) {
             checkNotNull(dimension, "the dimension builder was null");
-
 
             if (dimensionBuilders.build().contains(dimension))
                 throw new DuplicateDimensionException(

--- a/src/main/java/no/ssb/jsonstat/v2/Dimension.java
+++ b/src/main/java/no/ssb/jsonstat/v2/Dimension.java
@@ -16,14 +16,13 @@ import java.util.function.Function;
  * Created by hadrien on 07/06/16.
  * https://json-stat.org/format/#dimension
  */
-public class Dimension extends JsonStat {
+public class Dimension {
 
     private final Category category;
     // https://json-stat.org/format/#label
     private String label;
 
     public Dimension(Category category) {
-        super(Version.TWO, Class.DIMENSION);
         this.category = category;
     }
 
@@ -206,6 +205,11 @@ public class Dimension extends JsonStat {
                     );
             return withIndexedLabels(ImmutableMap.copyOf(newIndexedLabels));
 
+        }
+
+        public Builder withIndex(ImmutableSet<String> index) {
+          this.index.addAll(index);
+          return this;
         }
 
         /**

--- a/src/test/java/no/ssb/jsonstat/v2/DatasetTest.java
+++ b/src/test/java/no/ssb/jsonstat/v2/DatasetTest.java
@@ -142,7 +142,7 @@ public class DatasetTest {
                         "T", "population 15 years old and over"
                 )));
 
-        builder.withExtensionReference(ImmutableMap.of("arbitrary_field", "arbitrary_value"));
+        builder.withExtension(ImmutableMap.of("arbitrary_field", "arbitrary_value"));
 
         // TODO: addDimension("name") returning Dimension.Builder? Super fluent?
         // TODO: How to ensure valid data with the geo builder? Add the type first and extend builders?

--- a/src/test/java/no/ssb/jsonstat/v2/DatasetTest.java
+++ b/src/test/java/no/ssb/jsonstat/v2/DatasetTest.java
@@ -142,7 +142,7 @@ public class DatasetTest {
                         "T", "population 15 years old and over"
                 )));
 
-        builder.withExtension(ImmutableMap.of("arbitrary_field", "arbitrary_value"));
+        builder.withExtensionReference(ImmutableMap.of("arbitrary_field", "arbitrary_value"));
 
         // TODO: addDimension("name") returning Dimension.Builder? Super fluent?
         // TODO: How to ensure valid data with the geo builder? Add the type first and extend builders?

--- a/src/test/java/no/ssb/jsonstat/v2/DatasetTest.java
+++ b/src/test/java/no/ssb/jsonstat/v2/DatasetTest.java
@@ -142,6 +142,8 @@ public class DatasetTest {
                         "T", "population 15 years old and over"
                 )));
 
+        builder.withExtension(ImmutableMap.of("arbitrary_field", "arbitrary_value"));
+
         // TODO: addDimension("name") returning Dimension.Builder? Super fluent?
         // TODO: How to ensure valid data with the geo builder? Add the type first and extend builders?
         // TODO: express hierarchy with the builder? Check how ES did that with the query builders.
@@ -168,7 +170,6 @@ public class DatasetTest {
         Dataset build = builder.withValues(collect).build();
 
         assertThat(build).isNotNull();
-
     }
 
     @Test

--- a/src/test/java/no/ssb/jsonstat/v2/DimensionTest.java
+++ b/src/test/java/no/ssb/jsonstat/v2/DimensionTest.java
@@ -3,7 +3,7 @@ package no.ssb.jsonstat.v2;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import no.ssb.jsonstat.JsonStatModule;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -27,15 +27,10 @@ public class DimensionTest {
     public void testSerialize() throws Exception {
 
         Dimension dimension = Dimension.create("test")
-                .withIndexedLabels(ImmutableMap.of(
-                        "test", "test label",
-                        "test2", "test label2"
-                )).build();
+                .withIndex(ImmutableSet.of("index 0", "index 1")).build();
 
         String value = mapper.writeValueAsString(dimension);
-
         assertThat(value).isNotNull();
-
     }
 
     @Test(enabled = false)

--- a/src/test/java/no/ssb/jsonstat/v2/DimensionTest.java
+++ b/src/test/java/no/ssb/jsonstat/v2/DimensionTest.java
@@ -3,6 +3,7 @@ package no.ssb.jsonstat.v2;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import no.ssb.jsonstat.JsonStatModule;
 import org.testng.annotations.BeforeMethod;
@@ -28,8 +29,17 @@ public class DimensionTest {
 
         Dimension dimension = Dimension.create("test")
                 .withIndex(ImmutableSet.of("index 0", "index 1")).build();
-
         String value = mapper.writeValueAsString(dimension);
+
+        assertThat(value).isNotNull();
+
+        dimension = Dimension.create("test")
+                .withIndexedLabels(ImmutableMap.of(
+                        "test", "test label",
+                        "test2", "test label2"
+                )).build();
+        value = mapper.writeValueAsString(dimension);
+
         assertThat(value).isNotNull();
     }
 
@@ -37,5 +47,4 @@ public class DimensionTest {
     public void testDeserialize() throws Exception {
 
     }
-
 }


### PR DESCRIPTION
This revision: 
1. Removes `class` and `version` from the `Dimension` class, as the `Dimension` class is used internally to the `Dataset` class; the `dimension` field within `dataset` in the [schema](https://json-stat.org/format/schema/2.0/) does not include these and the presence of these fields is invalid according to the json-stat.org [validator](https://json-stat.org/format/validator/).
2. Adds the ability to provide only an `index` without a `label` in `dimension`. 
3. Adds the ability to supply an `extension` field to a `dataset`. 

Item (1) is for correctness (though a separate, top-level `dimension` response class will need to be created), while items (2) and (3) are features required for our own minimum viable prototyping and iteration.

Because this is not a confirmed release, pom.xml is not bumped.

Please let me know what changes you'd like to see before making this merge!
