### PR TITLE
Change datatypes

### DIFF
--- a/src/main/java/no/ssb/jsonstat/v2/DatasetValueBuilder.java
+++ b/src/main/java/no/ssb/jsonstat/v2/DatasetValueBuilder.java
@@ -32,7 +32,7 @@ public interface DatasetValueBuilder {
      * @param values the values in row-major order
      * @throws NullPointerException if values is null
      */
-    DatasetBuildable withValues(java.util.Collection<Number> values);
+    DatasetBuildable withValues(java.util.Collection<Object> values);
 
     /**
      * Populate the data set with values.
@@ -43,7 +43,7 @@ public interface DatasetValueBuilder {
      * @param values the values in row-major order
      * @throws NullPointerException if values is null
      */
-    DatasetBuildable withValues(Iterable<Number> values);
+    DatasetBuildable withValues(Iterable<Object> values);
 
     /**
      * Populate the data set with value lists.
@@ -66,7 +66,7 @@ public interface DatasetValueBuilder {
      * @param values the values in row-major order
      * @throws NullPointerException if values is null
      */
-    DatasetBuildable withValues(Stream<Number> values);
+    DatasetBuildable withValues(Stream<Object> values);
 
     /**
      * Use a mapper function to populate the metrics in the data set.
@@ -81,7 +81,7 @@ public interface DatasetValueBuilder {
      * @param mapper a mapper function to use to populate the metrics in the data set
      * @throws NullPointerException if mapper is null
      */
-    DatasetBuildable withMapper(Function<List<String>, Number> mapper);
+    DatasetBuildable withMapper(Function<List<String>, Object> mapper);
 
     /**
      * Add a tuple using the dimension values (categories) and values.
@@ -93,6 +93,6 @@ public interface DatasetValueBuilder {
      *                                  empty map is encountered
      * @throws NullPointerException     is dimensions or metric is null
      */
-    DatasetValueBuilder addTuple(List<String> dimensions, Number value);
+    DatasetValueBuilder addTuple(List<String> dimensions, Object value);
 
 }

--- a/src/main/java/no/ssb/jsonstat/v2/deser/DatasetDeserializer.java
+++ b/src/main/java/no/ssb/jsonstat/v2/deser/DatasetDeserializer.java
@@ -51,7 +51,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 public class DatasetDeserializer extends StdDeserializer<DatasetBuildable> {
 
-    static final TypeReference<List<Number>> VALUES_LIST = new TypeReference<List<Number>>() {
+    static final TypeReference<List<Object>> VALUES_LIST = new TypeReference<List<Object>>() {
     };
     static final TypeReference<Map<String, Dimension.Builder>> DIMENSION_MAP = new TypeReference<Map<String, Dimension.Builder>>() {
     };
@@ -61,7 +61,7 @@ public class DatasetDeserializer extends StdDeserializer<DatasetBuildable> {
     };
     static final TypeReference<ArrayListMultimap<String, String>> ROLE_MULTIMAP = new TypeReference<ArrayListMultimap<String, String>>() {
     };
-    static final TypeReference<?> VALUES_MAP = new TypeReference<TreeMap<Integer, Number>>() {
+    static final TypeReference<?> VALUES_MAP = new TypeReference<TreeMap<Integer, Object>>() {
     };
 
     static final DateTimeFormatter ECMA_FORMATTER = new DateTimeFormatterBuilder()
@@ -107,7 +107,7 @@ public class DatasetDeserializer extends StdDeserializer<DatasetBuildable> {
         List<Integer> sizes = Collections.emptyList();
         Multimap<String, String> roles = ArrayListMultimap.create();
         Map<String, Dimension.Builder> dims = Collections.emptyMap();
-        List<Number> values = Collections.emptyList();
+        List<Object> values = Collections.emptyList();
 
 
         DatasetBuilder builder = Dataset.create();
@@ -228,12 +228,12 @@ public class DatasetDeserializer extends StdDeserializer<DatasetBuildable> {
         return builder.withDimensions(orderedDimensions).withValues(values);
     }
 
-    List<Number> parseValues(JsonParser p, DeserializationContext ctxt) throws IOException {
-        List<Number> result = Collections.emptyList();
+    List<Object> parseValues(JsonParser p, DeserializationContext ctxt) throws IOException {
+        List<Object> result = Collections.emptyList();
         switch (p.getCurrentToken()) {
             case START_OBJECT:
-                SortedMap<Integer, Number> map = p.readValueAs(VALUES_MAP);
-                result = new AbstractList<Number>() {
+                SortedMap<Integer, Object> map = p.readValueAs(VALUES_MAP);
+                result = new AbstractList<Object>() {
 
                     @Override
                     public int size() {
@@ -241,7 +241,7 @@ public class DatasetDeserializer extends StdDeserializer<DatasetBuildable> {
                     }
 
                     @Override
-                    public Number get(int index) {
+                    public Object get(int index) {
                         return map.get(index);
                     }
                 };

--- a/src/main/java/no/ssb/jsonstat/v2/support/DatasetTableView.java
+++ b/src/main/java/no/ssb/jsonstat/v2/support/DatasetTableView.java
@@ -45,7 +45,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * An implementation of a {@link Table} that uses a {@link Dataset}
  * as data source.
  */
-public class DatasetTableView implements Table<List<String>, List<String>, Number> {
+public class DatasetTableView implements Table<List<String>, List<String>, Object> {
 
     private final Dataset source;
 
@@ -160,7 +160,7 @@ public class DatasetTableView implements Table<List<String>, List<String>, Numbe
 
     @Override
     public boolean containsValue(Object value) {
-        for (Map<List<String>, Number> row : rowMap().values()) {
+        for (Map<List<String>, Object> row : rowMap().values()) {
             if (row.containsValue(value)) {
                 return true;
             }
@@ -174,7 +174,7 @@ public class DatasetTableView implements Table<List<String>, List<String>, Numbe
     }
 
     @Override
-    public Number get(Object rowKey, Object columnKey) {
+    public Object get(Object rowKey, Object columnKey) {
         try {
             Iterator<String> rowList = ((List<String>) rowKey).iterator();
             Iterator<String> columnList = ((List<String>) columnKey).iterator();
@@ -204,14 +204,14 @@ public class DatasetTableView implements Table<List<String>, List<String>, Numbe
     }
 
     @Override
-    public Map<List<String>, Number> row(List<String> rowKey) {
-        return new AbstractMap<List<String>, Number>() {
+    public Map<List<String>, Object> row(List<String> rowKey) {
+        return new AbstractMap<List<String>, Object>() {
 
             @Override
-            public Set<Entry<List<String>, Number>> entrySet() {
-                return new AbstractSet<Entry<List<String>, Number>>() {
+            public Set<Entry<List<String>, Object>> entrySet() {
+                return new AbstractSet<Entry<List<String>, Object>>() {
                     @Override
-                    public Iterator<Entry<List<String>, Number>> iterator() {
+                    public Iterator<Entry<List<String>, Object>> iterator() {
                         return Iterators.transform(
                                 DatasetTableView.this.columnKeySet().iterator(),
                                 columnKey -> {
@@ -230,14 +230,14 @@ public class DatasetTableView implements Table<List<String>, List<String>, Numbe
     }
 
     @Override
-    public Map<List<String>, Number> column(List<String> columnKey) {
-        return new AbstractMap<List<String>, Number>() {
+    public Map<List<String>, Object> column(List<String> columnKey) {
+        return new AbstractMap<List<String>, Object>() {
 
             @Override
-            public Set<Entry<List<String>, Number>> entrySet() {
-                return new AbstractSet<Entry<List<String>, Number>>() {
+            public Set<Entry<List<String>, Object>> entrySet() {
+                return new AbstractSet<Entry<List<String>, Object>>() {
                     @Override
-                    public Iterator<Entry<List<String>, Number>> iterator() {
+                    public Iterator<Entry<List<String>, Object>> iterator() {
                         return Iterators.transform(
                                 DatasetTableView.this.rowKeySet().iterator(),
                                 rowKey -> {
@@ -256,7 +256,7 @@ public class DatasetTableView implements Table<List<String>, List<String>, Numbe
     }
 
     @Override
-    public Set<Cell<List<String>, List<String>, Number>> cellSet() {
+    public Set<Cell<List<String>, List<String>, Object>> cellSet() {
         Set<List<List<String>>> lists = Sets.cartesianProduct(rowKeySet(), columnKeySet());
         return lists.stream().map(dimensions -> {
             return Tables.immutableCell(dimensions.get(0), dimensions.get(1), get(dimensions.get(0), dimensions.get(1)));
@@ -264,18 +264,18 @@ public class DatasetTableView implements Table<List<String>, List<String>, Numbe
     }
 
     @Override
-    public Collection<Number> values() {
+    public Collection<Object> values() {
         return source.getRows();
     }
 
     @Override
-    public Map<List<String>, Map<List<String>, Number>> rowMap() {
-        return new AbstractMap<List<String>, Map<List<String>, Number>>() {
+    public Map<List<String>, Map<List<String>, Object>> rowMap() {
+        return new AbstractMap<List<String>, Map<List<String>, Object>>() {
             @Override
-            public Set<Entry<List<String>, Map<List<String>, Number>>> entrySet() {
-                return new AbstractSet<Entry<List<String>, Map<List<String>, Number>>>() {
+            public Set<Entry<List<String>, Map<List<String>, Object>>> entrySet() {
+                return new AbstractSet<Entry<List<String>, Map<List<String>, Object>>>() {
                     @Override
-                    public Iterator<Entry<List<String>, Map<List<String>, Number>>> iterator() {
+                    public Iterator<Entry<List<String>, Map<List<String>, Object>>> iterator() {
                         return Iterators.transform(
                                 rowKeySet().iterator(),
                                 rowKey -> {
@@ -295,13 +295,13 @@ public class DatasetTableView implements Table<List<String>, List<String>, Numbe
     }
 
     @Override
-    public Map<List<String>, Map<List<String>, Number>> columnMap() {
-        return new AbstractMap<List<String>, Map<List<String>, Number>>() {
+    public Map<List<String>, Map<List<String>, Object>> columnMap() {
+        return new AbstractMap<List<String>, Map<List<String>, Object>>() {
             @Override
-            public Set<Entry<List<String>, Map<List<String>, Number>>> entrySet() {
-                return new AbstractSet<Entry<List<String>, Map<List<String>, Number>>>() {
+            public Set<Entry<List<String>, Map<List<String>, Object>>> entrySet() {
+                return new AbstractSet<Entry<List<String>, Map<List<String>, Object>>>() {
                     @Override
-                    public Iterator<Entry<List<String>, Map<List<String>, Number>>> iterator() {
+                    public Iterator<Entry<List<String>, Map<List<String>, Object>>> iterator() {
                         return Iterators.transform(
                                 columnKeySet().iterator(),
                                 columnKey -> {
@@ -340,7 +340,7 @@ public class DatasetTableView implements Table<List<String>, List<String>, Numbe
      */
     @Deprecated
     @Override
-    public final Number put(List<String> rowKey, List<String> columnKey, Number value) {
+    public final Object put(List<String> rowKey, List<String> columnKey, Object value) {
         throw new UnsupportedOperationException();
     }
 
@@ -352,7 +352,7 @@ public class DatasetTableView implements Table<List<String>, List<String>, Numbe
      */
     @Deprecated
     @Override
-    public final void putAll(Table<? extends List<String>, ? extends List<String>, ? extends Number> table) {
+    public final void putAll(Table<? extends List<String>, ? extends List<String>, ? extends Object> table) {
         throw new UnsupportedOperationException();
     }
 
@@ -364,7 +364,7 @@ public class DatasetTableView implements Table<List<String>, List<String>, Numbe
      */
     @Deprecated
     @Override
-    public final Number remove(Object rowKey, Object columnKey) {
+    public final Object remove(Object rowKey, Object columnKey) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/test/java/no/ssb/jsonstat/v2/DatasetDeserializationTest.java
+++ b/src/test/java/no/ssb/jsonstat/v2/DatasetDeserializationTest.java
@@ -74,8 +74,8 @@ public class DatasetDeserializationTest {
 
         Dataset build = next.build();
 
-        Map<List<String>, Number> listListMap = build.asMap();
-        for (Map.Entry<List<String>, Number> listListEntry : listListMap.entrySet()) {
+        Map<List<String>, Object> listListMap = build.asMap();
+        for (Map.Entry<List<String>, Object> listListEntry : listListMap.entrySet()) {
             System.out.println(listListEntry);
         }
 
@@ -94,7 +94,7 @@ public class DatasetDeserializationTest {
 
         // Manually add extension
         node.with("extension")
-                .put("number", 10)
+                .put("Object", 10)
                 .putArray("array")
                 .add("string");
 
@@ -126,7 +126,7 @@ public class DatasetDeserializationTest {
                 DatasetBuildable.class
         ).build();
 
-        Map<Integer, Number> value = jsonStat.getValue();
+        Map<Integer, Object> value = jsonStat.getValue();
 
         // Check value order
         assertThat(value).isNotNull();
@@ -137,7 +137,7 @@ public class DatasetDeserializationTest {
         assertThat(value.get(2)).isEqualTo(3);
 
         // Check value + dimension coupling using asMap()
-        Iterable<Map.Entry<List<String>, Number>> limit = Iterables.limit(jsonStat.asMap().entrySet(), 3);
+        Iterable<Map.Entry<List<String>, Object>> limit = Iterables.limit(jsonStat.asMap().entrySet(), 3);
         assertThat(limit).containsExactly(
                 entry(asList("AA"), 1),
                 entry(asList("AB"), 2),
@@ -161,9 +161,9 @@ public class DatasetDeserializationTest {
         assertThat(jsonStat.getClazz()).isEqualTo("dataset");
         assertThat(jsonStat.getLabel()).contains("Population by province of residence, place of birth, age, gender and year in Galicia");
         assertThat(jsonStat.getSource()).contains("INE and IGE");
-        assertThat(jsonStat.getUpdated()).contains(Instant.parse("2012-12-27T12:25:09Z"));
+        assertThat(jsonStat.getUpdated()).contains(Instant.parse("2012-12-27T12:25:09Z").toString());
 
-        Iterable<Map.Entry<List<String>, Number>> limit = Iterables.limit(jsonStat.asMap().entrySet(), 5);
+        Iterable<Map.Entry<List<String>, Object>> limit = Iterables.limit(jsonStat.asMap().entrySet(), 5);
         assertThat(limit).containsExactly(
                 entry(asList("T", "T", "T", "2001", "T", "pop"), 2695880),
                 entry(asList("T", "T", "T", "2001", "15", "pop"), 1096027),

--- a/src/test/java/no/ssb/jsonstat/v2/DatasetTest.java
+++ b/src/test/java/no/ssb/jsonstat/v2/DatasetTest.java
@@ -272,7 +272,7 @@ public class DatasetTest {
         //        .withGeoRole());
 
         // Supplier.
-        List<Number> collect = cartesianProduct(
+        List<Object> collect = cartesianProduct(
                 ImmutableList.of("2003", "2004", "2005"),
                 ImmutableList.of("may", "june", "july"),
                 ImmutableList.of("30", "31", "32"),

--- a/src/test/java/no/ssb/jsonstat/v2/deser/DatasetDeserializerTest.java
+++ b/src/test/java/no/ssb/jsonstat/v2/deser/DatasetDeserializerTest.java
@@ -90,9 +90,9 @@ public class DatasetDeserializerTest {
         );
         arrayParser.nextValue();
 
-        List<Number> fromMap = ds.parseValues(mapParser, null);
-        List<Number> fromArray = ds.parseValues(arrayParser, null);
-        List<Number> expected = Lists.newArrayList(
+        List<Object> fromMap = ds.parseValues(mapParser, null);
+        List<Object> fromArray = ds.parseValues(arrayParser, null);
+        List<Object> expected = Lists.newArrayList(
                 10, 20, null, 30, 40
         );
 

--- a/src/test/java/no/ssb/jsonstat/v2/support/DatasetTableViewTest.java
+++ b/src/test/java/no/ssb/jsonstat/v2/support/DatasetTableViewTest.java
@@ -417,7 +417,7 @@ public class DatasetTableViewTest {
         );
     }
 
-    private Table.Cell<List<String>, List<String>, Number> cell(List<String> row, List<String> column, Number value) {
+    private Table.Cell<List<String>, List<String>, Object> cell(List<String> row, List<String> column, Object value) {
         return Tables.immutableCell(row, column, value);
     }
 


### PR DESCRIPTION
Updates:
1, Change datatype for values(Data) from Number to Object
2, Change return datatype of the getUpdated function from Instant to
String
3, Change return value of getRole function from builder.build() to
builder.build().asMap(), and return datatype from
ImmutableMultimap.Builder<Dimension.Roles, String> to
ImmutableMap<Dimension.Roles, Collection<String>>

Reasons:
1, Dataset values can be String datatype, not just Number datatype: e.g.: http://json-stat.org/samples/order.json
2, 3, Update the return datatypes of getUpdated and getRole so that the datasets can be converted correctly with Http Message Converters (http://www.baeldung.com/spring-httpmessageconverter-rest) .

Before update:
a) Instant object (.updatedAt(Instant.now())) : 
"updated": 1488273215.555
b) ImmutableMultimap<Dimension.Roles, String> object (.withMetricRole()) : 
"role": {
    "empty": false
  }
After update:
a) "updated": "2017-02-28T09:20:15.123Z"
b)   "role": {
    "metric": [
      "concept"
    ]
  }